### PR TITLE
[Shuffle Friends]

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -29,7 +29,7 @@ class GamesController < ApplicationController
   end
 
   def resend_notifications
-    game.resend_notifications
+    NotificationResender.new(game).resend_notifications
     redirect_to root_path, notice: "Invitations sent"
   end
 

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -18,6 +18,21 @@ class GamesController < ApplicationController
   def index
   end
 
+  def destroy
+    game.destroy
+    redirect_to root_path(), notice: "Game erased"
+  end
+
+  def shuffle
+    Shuffler.new(game).shuffle!
+    redirect_to root_path, notice: "Invitations sent"
+  end
+
+  def resend_notifications
+    game.resend_notifications
+    redirect_to root_path, notice: "Invitations sent"
+  end
+
   protected
   def game_params
      params.require(:game).permit(:name, :scheduled_on, :description)

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,4 +2,13 @@ class HomeController < ApplicationController
 
   def index
   end
+
+protected
+  def games
+     if current_user
+       current_user.games
+     end
+  end
+  helper_method :games
+
 end

--- a/app/mailers/friend_notifier.rb
+++ b/app/mailers/friend_notifier.rb
@@ -6,4 +6,11 @@ class FriendNotifier < ActionMailer::Base
     @game = game
     mail to: friend.email, subject: "#{ @game.user.name } created an invisible friend game"
   end
+
+  def notify_assignment(friend_assignment)
+    @giver = friend_assignment.giver
+    @receiver = friend_assignment.receiver
+    @game = friend_assignment.game
+    mail to: @giver.email, subject: "You are #{ @receiver.name }'s Invisible Friend!"
+  end
 end

--- a/app/models/friend_assignment.rb
+++ b/app/models/friend_assignment.rb
@@ -1,0 +1,7 @@
+class FriendAssignment < ActiveRecord::Base
+  belongs_to :game
+  belongs_to :giver, class_name: "User"
+  belongs_to :receiver, class_name: "User"
+
+  validates :game, :giver, :receiver, presence: true
+end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,8 +1,9 @@
 class Game < ActiveRecord::Base
 
   belongs_to :user
-  has_many :game_invitations
+  has_many :game_invitations, dependent: :destroy
   has_many :friends, through: :game_invitations, source: :user
+  has_many :friend_assignments, dependent: :destroy
 
 
   validates :name, :user, presence: true
@@ -11,4 +12,10 @@ class Game < ActiveRecord::Base
     message: 'must be a future date'
   }
 
+  def resend_notifications
+    friend_assignments.each do |fa|
+      FriendNotifier.notify_assignment(fa).deliver
+    end
+
+  end
 end

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -12,10 +12,4 @@ class Game < ActiveRecord::Base
     message: 'must be a future date'
   }
 
-  def resend_notifications
-    friend_assignments.each do |fa|
-      FriendNotifier.notify_assignment(fa).deliver
-    end
-
-  end
 end

--- a/app/services/notification_resender.rb
+++ b/app/services/notification_resender.rb
@@ -1,0 +1,14 @@
+class NotificationResender
+
+  def initialize(game)
+    @game = game
+  end
+
+  def resend_notifications
+    @game.friend_assignments.each do |fa|
+    FriendNotifier.notify_assignment(fa).deliver
+    end
+
+  end
+
+end

--- a/app/services/shuffler.rb
+++ b/app/services/shuffler.rb
@@ -1,0 +1,22 @@
+class Shuffler
+  def initialize(game)
+    @game = game
+  end
+
+  def shuffle!
+    participants = Array.new(@game.friends)
+    participants << @game.user
+    participants.shuffle!
+
+    for i in 0..participants.count-2 do
+      friend_assignment = FriendAssignment.new(giver: participants[i], receiver: participants[i+1])
+      @game.friend_assignments << friend_assignment
+      FriendNotifier.notify_assignment(friend_assignment).deliver
+
+    end
+    friend_assignment = FriendAssignment.new(giver: participants.last, receiver: participants.first)
+    @game.friend_assignments << friend_assignment
+    FriendNotifier.notify_assignment(friend_assignment).deliver
+
+  end
+end

--- a/app/views/friend_notifier/notify_assignment.text.erb
+++ b/app/views/friend_notifier/notify_assignment.text.erb
@@ -1,0 +1,3 @@
+Hello <%= @giver.name %>
+As a participant in <%= @game.name %>, you have to give a present to <%= @receiver.name %>.
+

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,28 @@
 Organice your Invisible Friends Game, just sign in with your Facebook account and start adding friends! <br/><br/>
 <% if notice %>
-  <%= notice %><br/>
+  <%= notice %><br/><br/>
 <% end %>
 <% if current_user %>
   <%= link_to "Add New Game", new_game_path %>
+  <% if games.count > 0 %>
+    <h3>Your Games</h3>
+  <% end %>
+  <table>
+    <% games.each do |game| %>
+      <tr>
+        <td><%= game.name %></td>
+        <td><%= link_to "Remove", game_path(game), method: :delete %></td>
+        <td>
+          <% if game.friend_assignments.count == 0 %>
+            <%= link_to "Shuffle", game_shuffle_path(game) %>
+          <% else %>
+            <%= link_to "Resend", game_resend_path(game) %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+   </table>
 <% else %>
   <%= link_to image_tag("/assets/loginfb.png", size: "240x115", alt: "Sign in with Facebook"), "/auth/facebook" %>
 <% end %>
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
   <div id="container">
     <header>
       <div id="banner">
-        <%= image_tag("/assets/present-box.png", size: "200x200") %>
+        <%= link_to image_tag("/assets/present-box.png", size: "200x200"), root_path %>
         <ul id="login">
           <% if current_user %>
             <li><%= current_user.name %></li>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,17 +27,16 @@ InvisibleFriends::Application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  #InvisibleFriends::Application.configure do
-  #    config.action_mailer.delivery_method = :smtp
-  #    config.action_mailer.smtp_settings = {
-  #      address:  ENV['MAIL_SMTP_SERVER'],
-  #      port:  ENV['MAIL_SMTP_PORT'],
-  #      domain:  ENV['MAIL_DOMAIN'],
-  #      authentication: ENV['MAIL_AUTHENTICATION'],
-  #      user_name: ENV['MAIL_USER_NAME'],
-  #      password:  ENV['MAIL_PASSWORD'],
-  #      enable_starttls_auto: true
-  #     }
-  #end
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:  ENV['MAIL_SMTP_SERVER'],
+    port:  ENV['MAIL_SMTP_PORT'],
+    domain:  ENV['MAIL_DOMAIN'],
+    authentication: ENV['MAIL_AUTHENTICATION'],
+    user_name: ENV['MAIL_USER_NAME'],
+    password:  ENV['MAIL_PASSWORD'],
+    enable_starttls_auto: true
+  }
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ InvisibleFriends::Application.routes.draw do
     resources :friends
   end
 
+  get "/games/:id/shuffle", to: "games#shuffle", as: "game_shuffle"
+  get "/games/:id/resend", to: "games#resend_notifications", as: "game_resend"
+
   match 'auth/:provider/callback', to: 'sessions#create', via: [:get]
   match 'auth/failure', to: redirect('/'), via: [:get]
   match 'signout', to: 'sessions#destroy', as: 'signout', via: [:get]

--- a/db/migrate/20140102172326_create_friend_assignments.rb
+++ b/db/migrate/20140102172326_create_friend_assignments.rb
@@ -1,0 +1,11 @@
+class CreateFriendAssignments < ActiveRecord::Migration
+  def change
+    create_table :friend_assignments do |t|
+      t.belongs_to :game, index: true
+      t.references :giver, index: true
+      t.references :receiver, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20131223002023) do
+ActiveRecord::Schema.define(version: 20140102172326) do
+
+  create_table "friend_assignments", force: true do |t|
+    t.integer  "game_id"
+    t.integer  "giver_id"
+    t.integer  "receiver_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "friend_assignments", ["game_id"], name: "index_friend_assignments_on_game_id"
+  add_index "friend_assignments", ["giver_id"], name: "index_friend_assignments_on_giver_id"
+  add_index "friend_assignments", ["receiver_id"], name: "index_friend_assignments_on_receiver_id"
 
   create_table "friends", force: true do |t|
     t.string   "name"

--- a/spec/factories/friend_assignments.rb
+++ b/spec/factories/friend_assignments.rb
@@ -1,0 +1,9 @@
+# Read about factories at https://github.com/thoughtbot/factory_girl
+
+FactoryGirl.define do
+  factory :friend_assignment do
+    game nil
+    giver nil
+    receiver nil
+  end
+end

--- a/spec/features/friend_management_spec.rb
+++ b/spec/features/friend_management_spec.rb
@@ -70,7 +70,7 @@ feature 'Friend management' do
 
   scenario 'Removing a friend from a game' do
 
-    friend = create(:user)
+    friend = build(:user)
     click_on('Add a friend')
     fill_in 'invitation_manager[name]', with: friend.name
     fill_in 'invitation_manager[email]', with: friend.email
@@ -80,6 +80,23 @@ feature 'Friend management' do
     expect { click_on("Remove") }.to change{ @game.friends.count }.by(-1)
     expect(page).to have_content 'User removed from the game'
 
+  end
+
+  scenario 'Attempt to add a friend twice' do
+
+    friend = build(:user)
+    click_on('Add a friend')
+    fill_in 'invitation_manager[name]', with: friend.name
+    fill_in 'invitation_manager[email]', with: friend.email
+    click_on('Add to Game')
+
+    click_on('Add a friend')
+    fill_in 'invitation_manager[name]', with: friend.name
+    fill_in 'invitation_manager[email]', with: friend.email
+    click_on('Add to Game')
+
+    expect(current_path).to eq game_friends_path(@game)
+    expect(page).to have_content("User #{ friend.name } (#{ friend.email }) is already invited to the game")
 
   end
 

--- a/spec/features/game_management_spec.rb
+++ b/spec/features/game_management_spec.rb
@@ -5,7 +5,6 @@ feature "game management" do
   background do
     visit '/'
     @data= auth_data
-
     sign_in_with_facebook @data
   end
 
@@ -41,6 +40,23 @@ feature "game management" do
     expect(current_path).to eq "/games"
     expect(page).to have_content("Name can't be blank")
     expect(page).to have_content("must be a future date")
+  end
+
+  scenario "Delete a game" do
+    game = create(:game)
+    friend = create(:friend)
+
+    game.friends << friend
+
+    User.find_by(uid: @data.uid).games << game
+
+    visit "/"
+
+    expect{ click_on('Remove') }.to change{ Game.count }.by(-1)
+
+    expect(Game.find_by(id: game.id)).to be_nil
+    expect(GameInvitation.find_by(game_id: game.id)).to be_nil
+
   end
 
 end

--- a/spec/features/shuffling_friends_spec.rb
+++ b/spec/features/shuffling_friends_spec.rb
@@ -6,27 +6,44 @@ feature "Friends shuffle" do
     visit '/'
     @data= auth_data
     sign_in_with_facebook @data
-  end
 
-  scenario "shuffles friends of a game" do
-    game = create(:game)
+    @game = create(:game)
 
     for i in 0..5
       @friend = create(:friend)
-      game.friends << @friend
-      User.find_by(uid: @data.uid).games << game
+      @game.friends << @friend
+      User.find_by(uid: @data.uid).games << @game
     end
     visit '/'
 
+  end
+
+  scenario "shuffles friends of a game" do
     clear_emails
 
     click_on("Shuffle")
 
     expect(page).to have_content("Invitations sent")
 
-    open_email(game.friends.last.email)
+    open_email(@game.friends.last.email)
 
-    current_email.should have_content(game.name)
+    current_email.should have_content(@game.name)
 
   end
+
+  scenario "resends invitations to game's friends" do
+    click_on("Shuffle")
+
+    clear_emails
+
+    click_on("Resend")
+
+    expect(page).to have_content("Invitations sent")
+
+    open_email(@game.friends.last.email)
+
+    current_email.should have_content(@game.name)
+
+  end
+
 end

--- a/spec/features/shuffling_friends_spec.rb
+++ b/spec/features/shuffling_friends_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper.rb'
+
+feature "Friends shuffle" do
+
+  background do
+    visit '/'
+    @data= auth_data
+    sign_in_with_facebook @data
+  end
+
+  scenario "shuffles friends of a game" do
+    game = create(:game)
+
+    for i in 0..5
+      @friend = create(:friend)
+      game.friends << @friend
+      User.find_by(uid: @data.uid).games << game
+    end
+    visit '/'
+
+    clear_emails
+
+    click_on("Shuffle")
+
+    expect(page).to have_content("Invitations sent")
+
+    open_email(game.friends.last.email)
+
+    current_email.should have_content(game.name)
+
+  end
+end

--- a/spec/models/friend_assignment_spec.rb
+++ b/spec/models/friend_assignment_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe FriendAssignment do
+
+  describe "Associations" do
+    it { should belong_to(:game) }
+    it { should belong_to(:giver) }
+    it { should belong_to(:receiver) }
+  end
+
+  describe "Validations" do
+    it { should validate_presence_of(:game) }
+    it { should validate_presence_of(:giver) }
+    it { should validate_presence_of(:receiver) }
+  end
+end

--- a/spec/services/shuffler_spec.rb
+++ b/spec/services/shuffler_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper.rb'
+
+describe Shuffler do
+
+  it "shuffles the participants of the game" do
+   game = create(:game)
+
+    for i in 0..5
+      @friend = create(:friend)
+      game.friends << @friend
+    end
+    Shuffler.new(game).shuffle!
+
+    expect(game.friend_assignments.count).to eq(game.friends.count + 1)
+
+  end
+
+end

--- a/spec/services/shuffler_spec.rb
+++ b/spec/services/shuffler_spec.rb
@@ -2,16 +2,36 @@ require 'spec_helper.rb'
 
 describe Shuffler do
 
-  it "shuffles the participants of the game" do
-   game = create(:game)
+  before :each do
+    @game = create(:game)
 
     for i in 0..5
       @friend = create(:friend)
-      game.friends << @friend
+      @game.friends << @friend
     end
-    Shuffler.new(game).shuffle!
+  end
 
-    expect(game.friend_assignments.count).to eq(game.friends.count + 1)
+  it "shuffles the participants of the game" do
+
+    Shuffler.new(@game).shuffle!
+
+    expect(@game.friend_assignments.count).to eq(@game.friends.count + 1)
+
+    givers = []
+    receivers = []
+    @game.friend_assignments.each do |fa|
+      givers    << fa.giver
+      receivers << fa.receiver
+    end
+
+    participants = Array.new(@game.friends)
+    participants << @game.user
+
+    expect(givers).to eq(givers.uniq)
+    expect(receivers).to eq(receivers.uniq)
+
+    expect(givers.sort).to eq(participants.sort)
+    expect(receivers.sort).to eq(participants.sort)
 
   end
 


### PR DESCRIPTION
- Remove game functionality and spec
- Adding a friend twice to a game spec
- FriendAssignment model and spec
- Shuffler Service to shuffle the game's friends and create the corresponding friend assigments
- Shuffler Service Spec
- notify_assigment method added to friend_notifier mailer: to send an email informing an user which friend should give a present to
- Shuffling friends feature spec
- NotificationSender Service created to handle the resending invitations feature
- Specs corrections.
